### PR TITLE
Add a trailing space after colon in ref link

### DIFF
--- a/autoload/pantondoc_keyboard.vim
+++ b/autoload/pantondoc_keyboard.vim
@@ -83,7 +83,7 @@ endfunction
 " }}}1
 " Inserts: {{{1
 function! pantondoc_keyboard#Insert_Ref()
-    execute "normal! ya\[o\<cr>\<esc>p$a:"
+    execute "normal! ya\[o\<cr>\<esc>p$a: "
 endfunction
 " }}}1
 


### PR DESCRIPTION
Reference links have the form `[key]: http://example.com`. Since we're dropped
into insert mode, having the whitespace pre-filled makes using the mapping
more fluid.
