### PR TITLE
Disable modules that rely on Vim version >= 7.4

### DIFF
--- a/plugin/pantondoc.vim
+++ b/plugin/pantondoc.vim
@@ -46,7 +46,9 @@ if !exists("g:pantondoc_enabled_modules")
 				\"keyboard" ]
 	if (v:version >= 704)
 		call extend(g:pantondoc_enabled_modules, modules_that_require_704)
-	else
+	endif
+else
+	if (v:version < 704)
 		let disabled = []
 		for module in modules_that_require_704
 			let idx = index(g:pantondoc_enabled_modules, module)
@@ -56,8 +58,8 @@ if !exists("g:pantondoc_enabled_modules")
 			endif
 		endfor
 		let msg = join(disabled, ", ")
-		echomsg 'The following modules require vim >= 7.4 and have been disabled '.
-			\'for now: ' . msg
+		echomsg 'The following modules require vim >= 7.4 and have been '
+			   \'disabled for now: ' . msg
 	endif
 endif
 "}}}


### PR DESCRIPTION
Instead of crashing and burning when run on vim version < 704, disable those modules that rely on 704.
- Only disable modules that were explicitly requested in vimrc (and show a message)
- Only add those modules to the defaults if vim version is >= 704

Sorry for noisy commit history, was testing across two machines and pushing/pulling was the fastest way to share.

Motivation for this fix was that it got annoying when pantondoc just error-ed out on without explicitly telling me why. And disabling the whole thing would have removed some of the functionality that does work despite the version requirements (e.g. folding).

Lastly I must admit that I have not been using pandontoc for too long, so if there are cross-module dependencies that would render this solution useless
