### PR TITLE
fix autoload module interpolation

### DIFF
--- a/ftplugin/pantondoc.vim
+++ b/ftplugin/pantondoc.vim
@@ -20,7 +20,7 @@ for module in g:pantondoc_enabled_modules
 endfor
 
 for module in s:enabled_modules
-    call pantondoc#{module}#Init()
+    exe 'call pantondoc#' . module . '#Init()'
 endfor
 
 let b:pantondoc_loaded = 1


### PR DESCRIPTION
So as you know we observed a very [noticeable slowdown](https://github.com/vim-pandoc/vim-pandoc-syntax/issues/40#issuecomment-35691367) after 00903de. I've successfully tracked this down to the way the modules are loaded. In `ftplugin/pantondoc.vim` line 22 where the modules are loaded:

``` vim
for module in s:enabled_modules
  call pantondoc#{module}#Init()
endfor
```

I changed the loop to `for module in []` and ran vim with `-V2` and noticed that when I opened a markdown file --- despite the modules list being empty --- it tried to source a file called `{module}.vim`, as if the interpolation wasn't working. This naturally slows things down since it tries to look in more and more places. I changed it back to the full list and noticed that the interpolation _was_ working; all of the appropriate modules were loaded. However, lo and behold, at the very end of this sourcing sequence, it again tried to source `{module}.vim`.

I don't know why it would even be trying to perform the loop body if the list were empty, perhaps my understanding of vim loops is incorrect, but it's definitely an oddity.

So the only alternative I could think of was to perform a literal interpolation using `exe`.

``` vim
for module in s:enabled_modules
  exe 'call pantondoc#' . module . '#Init()'
endfor
```

Running this with an empty list works as expected, files loaded instantly, and -V2 showed that it didn't try to source a non-sense file. Running it with the full list was still noticeably faster than the original interpolation method.
