### PR TITLE
fixes in folding

### DIFF
--- a/autoload/pantondoc/folding.vim
+++ b/autoload/pantondoc/folding.vim
@@ -47,7 +47,7 @@ function! pantondoc#folding#FoldExpr()
     if &ft == "markdown" || &ft == "pandoc"
 	" vim-pandoc-syntax sets this variable, so we can check if we can use
 	" syntax assistance in our foldexpr function
-	if exists("g:vim_pandoc_syntax_exists") && b:vim_pantondoc_use_basic_folding != 1)
+	if exists("g:vim_pandoc_syntax_exists") && b:vim_pantondoc_use_basic_folding != 1
 	    return pantondoc#folding#MarkdownLevelSA()
 	" otherwise, we use a simple, but less featureful foldexpr
 	else
@@ -118,7 +118,7 @@ endfunction
 " Basic foldexpr {{{2
 function! pantondoc#folding#MarkdownLevelBasic()
     if getline(v:lnum) =~ '^#\{1,6}'
-	return ">". len(matchstr(getline(v:lnum), '^\@1<=#\{1,6}'))
+	return ">". len(matchstr(getline(v:lnum), '^#\{1,6}'))
     elseif getline(v:lnum) =~ '^[^-=].\+$' && getline(v:lnum+1) =~ '^=\+$'
 	return ">1"
     elseif getline(v:lnum) =~ '^[^-=].\+$' && getline(v:lnum+1) =~ '^-\+$'
@@ -133,7 +133,7 @@ endfunction
 
 " Markdown foldtext {{{2
 function! pantondoc#folding#MarkdownFoldText()
-    return v:folddashes . " # " . matchstr(getline(v:foldstart), '\(#\{1,6} \)\@3<=.*')
+    return v:folddashes . " # " . matchstr(getline(v:foldstart), '\(#\{1,6} \)\@7<=.*')
 endfunction
 
 " Textile: {{{1


### PR DESCRIPTION
Comments to all chunks:
1. A typo: extra parenthesis breaks all folding
2. There is no need for look-behind here because `^` is zero-width and
   `len(matchstr(...))` will be same whereas `matchstr(...)` will trigger
   same way. (i already omitted similar look-behind in `MarkdownLevelSA()`)
3. There could be 6 `#` and one space: 7 bytes altogether
