### PR TITLE
Properly handles 7.4 warning in case where all incompatible modules disabled

### DIFF
--- a/plugin/pantondoc.vim
+++ b/plugin/pantondoc.vim
@@ -47,6 +47,7 @@ if !exists("g:pandoc#modules#disabled")
     let g:pandoc#modules#disabled = []
 endif
 if v:version < 704
+    let s:module_disabled = 0
     for incompatible_module in ["bibliographies", "command"]
 	" user might have disabled them himself, check that
 	if index(g:pandoc#modules#disabled, incompatible_module) == -1


### PR DESCRIPTION
This allows users of earlier versions of Vim (who cannot upgrade for whatever reason) to stop the somewhat annoying "these modules require vim >= 7.4 and have been disabled" warning on startup, by disabling all said modules manually like this:

```
let g:pandoc#modules#disabled = ["bibliographies", "command"]
```

Without this changeset, attempting to do the above will produce an error because `s:module_disabled` is undefined when the conditional testing its value is reached.
