### PR TITLE
wrap_args() must chack that arg contains '='

### DIFF
--- a/pythonx/vim_pandoc/command.py
+++ b/pythonx/vim_pandoc/command.py
@@ -134,7 +134,7 @@ class PandocCommand(object):
 
         c_opts, c_args = getopt.gnu_getopt(shlex.split(args), self.opts.shortopts, self.opts.longopts)
         def wrap_args(i):
-            if i[1] != '' and re.match('=', i[1]):
+            if re.search('=', i[1]):
                 return (i[0], re.sub('$', '"', re.sub('(.*)=', '\\1="', i[1])))
             else:
                 return (i[0], i[1])


### PR DESCRIPTION
Otherwise for

Pandoc! html -Fvimhl -FparaToSpanBlock -S --standalone

i am getting wrong command instance

pandoc -t html -o "example.html" -Fvimhl" -FparaToSpanBlock" -S
--standalone "example.md"

that won't produce new document
