### PR TITLE
don't treat rustAttribute as a fold marker

### DIFF
--- a/autoload/markdown/headers.vim
+++ b/autoload/markdown/headers.vim
@@ -4,7 +4,7 @@
 
 function! markdown#headers#CheckValidHeader(lnum) "{{{1
     if exists("g:vim_pandoc_syntax_exists")
-	if synIDattr(synID(a:lnum, 1, 1), "name") =~? '\(pandocDelimitedCodeBlock\|clojure\|comment\|yamlkey\)'
+	if synIDattr(synID(a:lnum, 1, 1), "name") =~? '\(pandocDelimitedCodeBlock\|rustAttribute\|clojure\|comment\|yamlkey\)'
 	    return 0
 	endif
     endif

--- a/autoload/pandoc/folding.vim
+++ b/autoload/pandoc/folding.vim
@@ -116,7 +116,7 @@ function! pandoc#folding#MarkdownLevelSA()
     let vline = getline(v:lnum)
     let vline1 = getline(v:lnum + 1)
     if vline =~ '^#\{1,6}'
-        if synIDattr(synID(v:lnum, 1, 1), "name") !~? '\(pandocDelimitedCodeBlock\|clojure\|comment\)'
+        if synIDattr(synID(v:lnum, 1, 1), "name") !~? '\(pandocDelimitedCodeBlock\|rustAttribute\|clojure\|comment\)'
 	    if g:pandoc#folding#mode == 'relative'
 		return ">". len(markdown#headers#CurrentHeaderAncestors(v:lnum))
 	    else


### PR DESCRIPTION
rustAttribute is from the official Rust vim plugins

By the way, I noticed I had to change this in two places. Perhaps it can be stored in some variable? Though I do notice that the one in headers.vim has `yamlkey`, which is not available in the one in folding.vim, so maybe they can't be merged and managed by a single configuration variable.
