### PR TITLE
Add a sane default for pandoc#format#ToggleAutoFormat()

### DIFF
--- a/autoload/pandoc/formatting.vim
+++ b/autoload/pandoc/formatting.vim
@@ -127,7 +127,7 @@ function! pandoc#formatting#DisableAutoformat()
     let b:pandoc_autoformat_enabled = 0
 endfunction
 function! pandoc#formatting#ToggleAutoformat()
-    if get(b:, 'pandoc_autoformat_enabled', 1) == 1
+    if get(b:, "pandoc_autoformat_enabled", 1) == 1
         let b:pandoc_autoformat_enabled = 0
     else
         let b:pandoc_autoformat_enabled = 1


### PR DESCRIPTION
Before the commit: an error is thrown on first invocation of ToggleAutoformat() because the variable doesn't exist.

After the commit: I added a check to see if the variable exists, and defaulted it to 1. No errors!
