### PR TITLE
[WIP] Add more sophisticated indentation rules

### DIFF
--- a/indent/pandoc.vim
+++ b/indent/pandoc.vim
@@ -1,0 +1,38 @@
+" File: indent/pandoc.vim
+" Description: Indentation of pandoc buffers
+" Author: Jake Zimmerman
+"
+" TODO:
+" - Detect more LaTeX regions which should be indented
+"   - Make this configurable
+" - Detect syntax within language blocks, and indent them appropriately
+"   - Make this configurable according to the existing configuration options
+" - Add documentation to help files
+
+
+if exists("b:did_indent")
+  finish
+endif
+
+runtime! indent/tex.vim
+
+let b:did_indent = 1
+
+setlocal indentexpr=GetPandocIndent()
+
+" Only define the function once.
+if exists("*GetPandocIndent")
+  finish
+endif
+
+function GetPandocIndent()
+  " Use information from syntax matching rules to determine if we're in a
+  " special indentation region
+  let l:stack = synstack(line('.'), col('.'))
+  if len(l:stack) > 0 && synIDattr(l:stack[0], 'name') == 'pandocLaTeXRegion'
+    return GetTeXIndent()
+  else
+    return -1
+  endif
+endfunc
+


### PR DESCRIPTION
This commit adds the file `indent/pandoc.vim`. Using this file, we can
start to define more sophisticated indentation rules. In this commit,
we're starting by just using the LaTeX indentation rules when we notice
that we're in a LaTeX region.

There are a few more things that could be cool to implement:
- [ ] Detect more LaTeX regions which should be indented
  - Right now, `'pandocLaTeXRegion'` is hard-coded. Ideally, we'd want
    to add support for all block-level LaTeX regions, and make which
    regions should be indented a configurable setting.
- [ ] Detect syntax within embedded language blocks, and indent them
  appropriately
  - We'd want to make this configurable according to the existing
    configuration options for i.e. syntax highlighting in embedded
    blocks

Right now this should be considered a work in progress. I wanted to get
it out early so people interested could give feedback. One last thing
that would need to happen before merging is
- [ ] write documentation for all new features

I haven't tested this too thoroughly yet, but in the first few moments I
used it, it was a huge breath of fresh air over no indentation.
