### PR TITLE
replace BuffWrite with BuffWritePost to make autoexec work in neovim

### DIFF
--- a/autoload/pandoc/command.vim
+++ b/autoload/pandoc/command.vim
@@ -48,7 +48,7 @@ function! pandoc#command#Init()
                     \ PandocTemplate call pandoc#command#PandocTemplate("<args>")
 
     " set up auto-execution
-    au! BufWrite <buffer> call pandoc#command#AutoPandoc()
+    au! BufWritePost <buffer> call pandoc#command#AutoPandoc()
 endfunction
 
 " :Pandoc command {{{1


### PR DESCRIPTION
fixes #157 