### PR TITLE
expand filename before calling xdg-open

### DIFF
--- a/autoload/pandoc/hypertext.vim
+++ b/autoload/pandoc/hypertext.vim
@@ -224,7 +224,7 @@ function! pandoc#hypertext#OpenSystem(...)
     endif
 
     if has("unix") && executable("xdg-open")
-        call system("xdg-open ". addr)
+        call system("xdg-open ". shellescape(expand(addr,':p')))
     elseif has("win32") || has("win64")
         call system('cmd /c "start '. addr .'"')
     elseif has("macunix")


### PR DESCRIPTION
The call to expand before calling ``xdg-open`` makes it possible to have links like ``[file](~/something/in/your/home)``. Moreover, the ``shellescape()`` deals with complicated filenames.