### PR TITLE
introduce g:pandoc#hypertext#editable_alternates_extensions

### DIFF
--- a/autoload/pandoc/hypertext.vim
+++ b/autoload/pandoc/hypertext.vim
@@ -4,6 +4,9 @@ function! pandoc#hypertext#Init()
     if !exists("g:pandoc#hypertext#open_editable_alternates")
         let g:pandoc#hypertext#open_editable_alternates = 1
     endif
+    if !exists("g:pandoc#hypertext#editable_alternates_extensions")
+        let g:pandoc#hypertext#editable_alternates_extensions ='\(pdf\|htm\|odt\|doc\)'
+    endif
     if !exists("g:pandoc#hypertext#create_if_no_alternates_exists")
         let g:pandoc#hypertext#create_if_no_alternates_exists = 0
     endif
@@ -222,7 +225,7 @@ function! pandoc#hypertext#OpenLocal(...)
 
     if g:pandoc#hypertext#open_editable_alternates == 1
         let ext = fnamemodify(addr, ":e")
-        if ext =~ '\(pdf\|htm\|odt\|doc\)'
+        if ext =~ g:pandoc#hypertext#editable_alternates_extensions
             let alt_addrs = s:FindAlternates(addr)
             if alt_addrs != []
                 let pos = 0
@@ -283,8 +286,8 @@ function! pandoc#hypertext#OpenLink(cmd)
 
     if '#' == url[:0]
         call pandoc#hypertext#GotoID(url[1:])
-    elseif ext =~ '\(pdf\|htm\|odt\|doc\)' || s:IsEditable(url)
-        call pandoc#hypertext#OpenLocal(url, a:cmd)
+    elseif ext =~ g:pandoc#hypertext#editable_alternates_extensions || s:IsEditable(url)
+        call pandoc#hypertext#OpenLocal(url)
     else
         call pandoc#hypertext#OpenSystem(url)
     endif

--- a/doc/pandoc.txt
+++ b/doc/pandoc.txt
@@ -856,10 +856,16 @@ A description of the available configuration variables follows:
 - *g:pandoc#hypertext#open_editable_alternates*
   default = 1
 
-  If opening locally files with *.pdf, *.html, *.odt and *.doc extensions, try
-  to open a vim editable file instead. For example, if you try to open
-  "test.html" and "test.md" is available in the same folder, vim will try to
-  edit "test.md".
+  If opening locally files matching
+  |g:pandoc#hypertext#editable_alternates_extensions|, try to open a vim
+  editable file instead. For example, if you try to open "test.html" and
+  "test.md" is available in the same folder, vim will try to edit "test.md".
+
+- *g:pandoc#hypertext#editable_alternates_extensions*
+  default = '\(pdf\|htm\|odt\|doc\)'
+
+  A regular expression determining for what files a vim editable file
+  should be opened instead when opening locally.
 
 - *g:pandoc#hypertext#preferred_alternate*
   default = "md"


### PR DESCRIPTION
Introduce a variable for file extensions that ``vim-pandoc`` looks for editable alternates instead of having it hardcoded.