### PR TITLE
Require more than one - or = in setext headers

### DIFF
--- a/autoload/markdown/headers.vim
+++ b/autoload/markdown/headers.vim
@@ -25,7 +25,7 @@ function! markdown#headers#NextHeader(...) "{{{1
         let search_from = getpos(".")
     endif
     call cursor(search_from[1], 2)
-    let h_lnum = search('\(^.*\n[-=]\|^#\)','nW')
+    let h_lnum = search('\(^.*\n[-=]\{2\}\|^#\)','nW')
     if h_lnum != 0 && markdown#headers#CheckValidHeader(h_lnum) != 1
         let h_lnum = markdown#headers#NextHeader(h_lnum)
     endif
@@ -46,7 +46,7 @@ function! markdown#headers#PrevHeader(...) "{{{1
         let search_from = origin_pos
     endif
     call cursor(search_from[1], 1)
-    let h_lnum = search('\(^.*\n[-=]\|^#\)', 'bnW')
+    let h_lnum = search('\(^.*\n[-=]\{2\}\|^#\)', 'bnW')
     if h_lnum != 0 && markdown#headers#CheckValidHeader(h_lnum) != 1
         let h_lnum = markdown#headers#PrevHeader(h_lnum)
         " we might go back into the YAML frontmatter, we must recheck if we


### PR DESCRIPTION
If we require only one - or = to denote a header, then the following
gets detected as a header:

- this line is not a header, but appears to be one
- just a dot point

This should fix #150.