### PR TITLE
put --reference-links in extra_equalprg

### DIFF
--- a/autoload/pandoc/formatting.vim
+++ b/autoload/pandoc/formatting.vim
@@ -43,7 +43,7 @@ function! pandoc#formatting#Init() "{{{1
     " equalprg {{{3
     if !exists("g:pandoc#formatting#equalprg")
         if executable('pandoc')
-            let g:pandoc#formatting#equalprg = "pandoc -t markdown --reference-links"
+            let g:pandoc#formatting#equalprg = "pandoc -t markdown"
             if g:pandoc#formatting#mode =~ "h"
                 let g:pandoc#formatting#equalprg.= " --columns ".g:pandoc#formatting#textwidth
             else
@@ -55,7 +55,7 @@ function! pandoc#formatting#Init() "{{{1
     endif
     " extend the value of equalprg if needed
     if !exists("g:pandoc#formatting#extra_equalprg")
-        let g:pandoc#formatting#extra_equalprg = ""
+        let g:pandoc#formatting#extra_equalprg = "--reference-links"
     endif
     " }}}3
     " Use a custom indentexpr? {{{3

--- a/doc/pandoc.txt
+++ b/doc/pandoc.txt
@@ -622,7 +622,7 @@ A description of the available configuration variables follows:
   enabled, it might cause some lag.
 
 - *g:pandoc#formatting#equalprg*
-  default = "pandoc -t markdown --reference-links [--columns {g:pandoc#formatting#textwidth}|no-wrap]"
+  default = "pandoc -t markdown [--columns {g:pandoc#formatting#textwidth}|--wrap=none]"
 
   What command to use for equalprg. If set to '', vim's default will be used.
   See |'equalprg'|.
@@ -630,7 +630,7 @@ A description of the available configuration variables follows:
   or soft wraps.
 
 - *g:pandoc#formatting#extra_equalprg*
-  default = ""
+  default = "--reference-links"
 
   Extra arguments to append to the value of equalprg. Useful when the default
   behavior of |g:pandoc#formatting#equalprg| wants to be preserved.


### PR DESCRIPTION
Not everyone likes `--reference-links` and setting `equalprg` is
loses the `--columns/--wrap=none` logic.

This way it is still a default, but can be turned off.