### PR TITLE
Fix regex to capture optional long options

### DIFF
--- a/pythonx/vim_pandoc/command.py
+++ b/pythonx/vim_pandoc/command.py
@@ -86,7 +86,7 @@ class PandocHelpParser(object):
         data = str(Popen(["pandoc", "--help"], stdout=PIPE).communicate()[0])
         return map(lambda i: i.replace("--", ""), \
                    filter(lambda i: i not in ("--version", "--help", "--to", "--write"), \
-                          [ i.group() for i in re.finditer("-(-\w+)+=?", data)]))
+                          [ ''.join(i.groups()) for i in re.finditer("--([-\w]+)+\[?(=?)\w*\]?", data)]))
 
     @staticmethod
     def get_shortopts():


### PR DESCRIPTION
The regex to capture long options with optional arguments (like `--katex[=URL]`) fails due to the square brackets. The attached patch fixes this for me.