### PR TITLE
add matchit and list patterns

### DIFF
--- a/ftplugin/pandoc.vim
+++ b/ftplugin/pandoc.vim
@@ -23,4 +23,13 @@ for module in s:enabled_modules
     exe 'call pandoc#' . module . '#Init()'
 endfor
 
+if exists("loaded_matchit")
+    setlocal matchpairs-=<:>
+    let b:match_words = &l:matchpairs .
+      \ ',' . '\%(^\|[ (]\)\@<=\$\$\?' . ':' . '\$\?\$\%($\|[ ).\,;\:?!\-]\)' .
+      \ ',' . '\%(^\s*\)\@<=\\begin{\w\+\*\?}' . ':' . '\%(^\s*\)\@<=\\end{\w\+\*\?}'
+endif
+
+setlocal formatlistpat=^\\s*[\\[({]\\\?\\([0-9]\\+\\\|[iIvVxXlLcCdDmM]\\+\\\|[a-zA-Z]\\)[\\]:.)}]\\s\\+\\\|^\\s*[-+o*]\\s\\+
+
 let b:pandoc_loaded = 1


### PR DESCRIPTION
- matchit now recognizes math delimiters in pandoc 
- lists are recognized