### PR TITLE
Allow suppression of module-disabled warnings

### DIFF
--- a/doc/pandoc.txt
+++ b/doc/pandoc.txt
@@ -58,6 +58,12 @@ To check if the requirements are satisfied, check if
 
 outputs "1".
 
+The warning message when modules are automatically disabled can be suppressed
+by using
+>
+    let g:pandoc#modules#warn_disabled = 0
+
+
 INSTALLATION                                          *vim-pandoc-installation*
 
 The plugin follows the usual bundle structure, so it's easy to install it

--- a/plugin/pandoc.vim
+++ b/plugin/pandoc.vim
@@ -50,6 +50,9 @@ endif
 if !exists("g:pandoc#modules#disabled")
     let g:pandoc#modules#disabled = []
 endif
+if !exists('g:pandoc#modules#warn_disabled')
+    let g:pandoc#modules#warn_disabled = 1
+endif
 if v:version < 704
     let s:module_disabled = 0
     for incompatible_module in ["bibliographies", "command"]
@@ -61,7 +64,7 @@ if v:version < 704
     endfor
     " only message the user if we have extended g:pandoc#modules#disabled
     " automatically
-    if s:module_disabled == 1
+    if s:module_disabled == 1 && g:pandoc#modules#warn_disabled
         echomsg "vim-pandoc: 'bibliographies' and 'command' modules require vim >= 7.4 and have been disabled."
     endif
 endif


### PR DESCRIPTION
I suspect for many this isn't a major problem, but I'm finding the warnings about modules being disabled by default on older versions of vim becoming distracting. This PR adds a new configuration variable and checks it before issuing the warning.

The default behaviour is not changed - users must explicitly disable the warning by setting the variable.
