### PR TITLE
Add support for Pandoc 1.19 and above.

### DIFF
--- a/pythonx/vim_pandoc/command.py
+++ b/pythonx/vim_pandoc/command.py
@@ -116,14 +116,14 @@ class PandocHelpParser(object):
 
     @staticmethod
     def _get_input_formats():
-        if get_pandoc_version() == '1.18':
+        if get_pandoc_version() >= '1.18':
             return get_raw_pandoc_data(None, '--list-input-formats').splitlines()
         else:
             return wrap_formats(get_raw_pandoc_data("Input formats:(.*)Output formats", ))
 
     @staticmethod
     def _get_output_formats():
-         if get_pandoc_version() == '1.18':
+         if get_pandoc_version() >= '1.18':
             return get_raw_pandoc_data(None, '--list-output-formats').splitlines()
          else:
             return wrap_formats(get_raw_pandoc_data("Output formats:(.*)\[\*+for pdf"))


### PR DESCRIPTION
In Pandoc 1.18 the help syntax to find input and output formats was
changed. To that end there was made an exception that checked
specifically for a version that was 1.18 in order to find the formats in
this new version. Pandoc is now in version 1.19 and follows the same
pattern as 1.18 and it is expected to continue like that, so as an easy
fix the if condition has been changed to include future versions as
well.