### PR TITLE
bib/fallback.py: bibliography data can be bytes

### DIFF
--- a/pythonx/vim_pandoc/bib/fallback.py
+++ b/pythonx/vim_pandoc/bib/fallback.py
@@ -34,6 +34,8 @@ def get_bibtex_suggestions(text, query, use_bibtool=False, bib=None):
 
         args = "-- select{$key title booktitle author editor \"%(query)s\"}'" % {"query": query}
         text = sp.Popen(["bibtool", "--preserve.key.case=on",  args, bib], stdout=sp.PIPE, stderr=sp.PIPE).communicate()[0]
+        if isinstance(text, bytes):
+            text = text.decode("utf-8")
     else:
         bibtex_id_search = re.compile(".*{\s*(?P<id>" + query + ".*),")
 


### PR DESCRIPTION
On the Mac, reading from BIBTool produces `bytes`, so that the `re.sub()` in `get_bibtex_suggestions()`
fails.

(On Linux, I get no such error; this is python 3.5 or 3.6 on the Mac with vim 8.0.237 built from MacPorts, and python 3.5 with vim 8.249 on Linux.)