### PR TITLE
allow --smart/-S to be passed with no arguments

### DIFF
--- a/pythonx/vim_pandoc/command.py
+++ b/pythonx/vim_pandoc/command.py
@@ -223,6 +223,15 @@ class PandocCommand(object):
         else:
             extra_mathjax = False
 
+        if re.search('--smart( |$)', args):
+            args = re.sub('--smart', '', args)
+            extra_smart = True
+        elif re.search('-S( |$)', args):
+            args = re.sub('-S', '', args)
+            extra_smart = True
+        else:
+            extra_smart = False
+
         c_opts, c_args = getopt.gnu_getopt(shlex.split(args),
                                            self.opts.shortopts,
                                            self.opts.longopts)
@@ -274,6 +283,8 @@ class PandocCommand(object):
             extra.append(opt[0] + (eq or ' ') + '"' + val + '"')
         if extra_mathjax:
             extra.append('--mathjax')
+        if extra_smart:
+            extra.append('--smart')
 
         extra_args = " ".join(extra)
 


### PR DESCRIPTION
It's broken otherwise