### PR TITLE
python/pandoc/command: fix empty quoted arguments

### DIFF
--- a/pythonx/vim_pandoc/command.py
+++ b/pythonx/vim_pandoc/command.py
@@ -271,7 +271,8 @@ class PandocCommand(object):
                 eq = "="
             # if it begins with ~, it will expand, otherwise, it will just copy
             val = os.path.expanduser(opt[1])
-            extra.append(opt[0] + (eq or ' ') + '"' + val + '"')
+            extra.append(opt[0] + (eq or ' ')
+                + (('"' + val + '"') if len(val) else ''))
         if extra_mathjax:
             extra.append('--mathjax')
 


### PR DESCRIPTION
Previously, using arguments such as `Pandoc html -s` would produce a command like `pandoc -o a.html -s "" a.md`, resulting in pandoc complaining about a missing `""` file. This commit fixes this behavior by not adding extra quotes if an argument is only a flag.

Related: #219 