### PR TITLE
Fix #168

### DIFF
--- a/autoload/markdown/headers.vim
+++ b/autoload/markdown/headers.vim
@@ -384,7 +384,7 @@ function! markdown#headers#GetAutomaticID(header) " {{{1
     if !exists("header_id") || header_id == ""
         let text = substitute(a:header, '\[\(.\{-}\)\]\[.*\]', '\1', '') " remove links
         let text = substitute(text, '\s{.*}', '', '') " remove attributes
-        let text = substitute(text, '[[:punct:]]', '', 'g') " remove formatting and punctuation
+        let text = substitute(text, '[!"#\$%\&''()\*+,/:;<=>?@\[\\\]\^`{|}\~]', '', 'g') " remove formatting and punctuation, except -_. (hyphen, underscore, period)
         let text = substitute(text, '.\{-}[[:alpha:]\u20AC-\uFFFF]\@=', '', '') " remove everything before the first letter
         let text = substitute(text, '\s', '-', 'g') " replace spaces with dashes
         let text = tolower(text) " turn lowercase

--- a/autoload/pandoc/hypertext.vim
+++ b/autoload/pandoc/hypertext.vim
@@ -333,7 +333,7 @@ function! pandoc#hypertext#GotoID(...)
         if line > 0
             call cursor(line, 1)
         else
-            call pandoc#hypertext#GotoSavedCursor()
+            call pandoc#hypertext#BackFromLink()
         endif
     endif
 endfunction


### PR DESCRIPTION
Changes:

- Fix the error showed in #168 by replacing the obsolete `pandoc#hypertext#GotoSavedCursor` call with a call to `pandoc#hypertext#BackFromLink`
- Fix wrong `markdown#headers#GetAutomaticID` behavior, which erroneously removed hyphens and underscores and periods. (also mentioned in #168)