### PR TITLE
Add support for Panzer and other preprocessors

### DIFF
--- a/autoload/pandoc/command.vim
+++ b/autoload/pandoc/command.vim
@@ -33,6 +33,18 @@ function! pandoc#command#Init()
     if !exists("g:pandoc#command#autoexec_command")
         let g:pandoc#command#autoexec = ''
     endif
+    " path to pandoc executable
+    if !exists("g:pandoc#command#path")
+        let g:pandoc#command#path = 'pandoc'
+    endif
+    " custom command to execute instead of pandoc
+    if !exists("g:pandoc#compiler#command")
+        let g:pandoc#compiler#command = g:pandoc#command#path
+    endif
+    " custom command arguments
+    if !exists("g:pandoc#compiler#arguments")
+        let g:pandoc#compiler#arguments = ''
+    endif
 
     " create :Pandoc {{{2
     if has("python") || has("python/dyn") || has("python3") || has("python3/dyn")
@@ -74,7 +86,7 @@ function! pandoc#command#Pandoc(args, bang)
 endfunction
 
 function! pandoc#command#PandocNative(args)
-    let l:cmd = 'pandoc '.a:args. ' '.fnameescape(expand('%'))
+    let l:cmd = g:pandoc#compiler#command.' '.g:pandoc#compiler#arguments.' '.a:args.' '.fnameescape(expand('%'))
     if has('job')
         call job_start(l:cmd)
     else

--- a/compiler/pandoc.vim
+++ b/compiler/pandoc.vim
@@ -2,7 +2,8 @@ if exists("current_compiler")
   finish
 endif
 
-let current_compiler = "pandoc"
+let current_compiler = (exists('g:pandoc#compiler#command') ? g:pandoc#compiler#command : "pandoc")
+let compiler_args = (exists('g:pandoc#compiler#arguments') ? escape(' '.g:pandoc#compiler#arguments, '\ ') : "")
 
 CompilerSet errorformat="%f",\ line\ %l:\ %m
-CompilerSet makeprg=pandoc
+execute "CompilerSet makeprg=".current_compiler.compiler_args

--- a/doc/pandoc.txt
+++ b/doc/pandoc.txt
@@ -674,6 +674,12 @@ A description of the available configuration variables follows:
 
   As |g:pandoc#command#latex_engine|, but for the current file.
 
+- *g:pandoc#command#path*
+  default = "pandoc"
+
+  The name of the pandoc command. Can also be an absolute path if the program
+  is not located in the $PATH.
+
 - *g:pandoc#command#custom_open*
   default = ""
 
@@ -707,6 +713,25 @@ A description of the available configuration variables follows:
   default = split(&runtimepath, ",")[0]."/vim-pandoc-templates"
 
   Where to save and retrieve command templates.
+
+- *g:pandoc#compiler#command*
+  default = "{g:pandoc#command#path}"
+
+  The name of the command invoked in |:Pandoc|. Can also be an absolute path
+  if the program is not located in the $PATH.
+
+  The difference to *g:pandoc#command#path* is that the latter is used for
+  internal purposes. For example, if you want to use Panzer:
+
+    let g:pandoc#compiler#command = "panzer"
+
+- *g:pandoc#compiler#arguments*
+  default = ''
+
+  Additional arguments for the command invoked in |:Pandoc|.
+  For example, if you're using Panzer this setting is recommended:
+
+    let g:pandoc#compiler#arguments = "---quiet ---strict"
 
 - *g:pandoc#biblio#sources*
   default = "bcg"

--- a/pythonx/vim_pandoc/command.py
+++ b/pythonx/vim_pandoc/command.py
@@ -64,13 +64,13 @@ markdown_extensions = [
         ]
 #}}}
 def get_pandoc_version():
-    data = str(Popen(["pandoc", "--version"], stdout=PIPE).communicate()[0])
+    data = str(Popen([vim.vars["pandoc#command#path"], "--version"], stdout=PIPE).communicate()[0])
     m = re.search("pandoc (\d+\.\d+)", data)
     if m:
         return m.group(1)
 
 def get_raw_pandoc_data(pattern, cmd="--help"):
-    data = Popen(["pandoc", cmd], stdout=PIPE).communicate()[0]
+    data = Popen([vim.vars["pandoc#command#path"], cmd], stdout=PIPE).communicate()[0]
     if type(data) == bytes:
         data = data.decode()
     if cmd == "--help":
@@ -88,20 +88,20 @@ def wrap_formats(data):
 
 class PandocHelpParser(object):
     def __init__(self):
-        self._help_data = Popen(["pandoc", "--help"], stdout=PIPE).communicate()[0]
+        self._help_data = Popen([vim.vars["pandoc#command#path"], "--help"], stdout=PIPE).communicate()[0]
         self.longopts = list(PandocHelpParser.get_longopts())
         self.shortopts = PandocHelpParser.get_shortopts()
 
     @staticmethod
     def get_longopts():
-        data = str(Popen(["pandoc", "--help"], stdout=PIPE).communicate()[0])
+        data = str(Popen([vim.vars["pandoc#command#path"], "--help"], stdout=PIPE).communicate()[0])
         return map(lambda i: i.replace("--", ""), \
                    filter(lambda i: i not in ("--version", "--help", "--to", "--write"), \
                           [ ''.join(i.groups()) for i in re.finditer("--([-\w]+)+\[?(=?)\w*\]?", data)]))
 
     @staticmethod
     def get_shortopts():
-        data = str(Popen(["pandoc", "--help"], stdout=PIPE).communicate()[0])
+        data = str(Popen([vim.vars["pandoc#command#path"], "--help"], stdout=PIPE).communicate()[0])
         no_args = list(map(lambda i: i.replace("-", "").strip(), \
                       filter(lambda i: i not in ("-v ", "-h "), \
                              [i.group() for i in re.finditer("-\w\s(?!\w+)", data)])))
@@ -283,7 +283,8 @@ class PandocCommand(object):
 
         input_arg = '"' + vim.eval('expand("%")') + '"'
 
-        arglist = ["pandoc", \
+        arglist = [vim.vars['pandoc#compiler#command'], \
+                   vim.vars['pandoc#compiler#arguments'], \
                    bib_arg, \
                    strict_arg, \
                    output_format_arg, \


### PR DESCRIPTION
Since I mostly want to use _Panzer_ to create my documents using central style definitions, I built in three settings that allow users to define what program should be executed instead of `pandoc`.

My pandoc setup in vimrc looks like this:
```viml
let g:pandoc#compiler#command = 'panzer'
let g:pandoc#compiler#arguments = '---quiet ---strict'
```

The third setting, `g:pandoc#command#path` is only necessary if `pandoc` is not found in the user's PATH. _RStudio_, e.g., includes pandoc in its application bundle.

I hope I didn't overlook any place where a call to `pandoc` is hardcoded.