### PR TITLE
Fixed bug with `j` and `k` user map restoration

### DIFF
--- a/autoload/pandoc/formatting.vim
+++ b/autoload/pandoc/formatting.vim
@@ -285,25 +285,25 @@ function! pandoc#formatting#UseHardWraps() abort "{{{1
     " restore j and k
     " based on http://vi.stackexchange.com/a/7735/6682
     if exists('l:save_j')
-        " restore visual mode mapping for j
+        " restore normal mode mapping for j
         exec (l:save_j.noremap ? 'nnoremap' : 'nmap') .
              \ join(map(['buffer', 'expr', 'nowait', 'silent'], 'l:save_j[v:val] ? "<" . v:val . ">": ""')) .
              \ l:save_j.lhs . ' ' .
              \ substitute(l:save_j.rhs, '<SID>', '<SNR>' . l:save_j.sid . '_', 'g')
         " restore visual mode mapping for j
-        exec (l:save_j.noremap ? 'nnoremap' : 'nmap') .
+        exec (l:save_j.noremap ? 'vnoremap' : 'vmap') .
              \ join(map(['buffer', 'expr', 'nowait', 'silent'], 'l:save_j[v:val] ? "<" . v:val . ">": ""')) .
              \ l:save_j.lhs . ' ' .
              \ substitute(l:save_j.rhs, '<SID>', '<SNR>' . l:save_j.sid . '_', 'g')
     endif
     if exists('l:save_k')
-        " restore visual mode mapping for k
+        " restore normal mode mapping for k
         exec (l:save_k.noremap ? 'nnoremap' : 'nmap') .
              \ join(map(['buffer', 'expr', 'nowait', 'silent'], 'l:save_k[v:val] ? "<" . v:val . ">": ""')) .
              \ l:save_k.lhs . ' ' .
              \ substitute(l:save_k.rhs, '<SID>', '<SNR>' . l:save_k.sid . '_', 'g')
         " restore visual mode mapping for k
-        exec (l:save_k.noremap ? 'nnoremap' : 'nmap') .
+        exec (l:save_k.noremap ? 'vnoremap' : 'vmap') .
              \ join(map(['buffer', 'expr', 'nowait', 'silent'], 'l:save_k[v:val] ? "<" . v:val . ">": ""')) .
              \ l:save_k.lhs . ' ' .
              \ substitute(l:save_k.rhs, '<SID>', '<SNR>' . l:save_k.sid . '_', 'g')


### PR DESCRIPTION
In issue #198, some code was added to formatting.vim that is supposed to
restore user mappings for j and k, if they existed beforehand. The
normal mode mapping was being restored correctly, but the visual mode
mapping was still getting dropped on the floor. It turns out the blocks
for the visual and normal mappings were exact copies of each other. This
commit makes the minor tweak necessary to actually restore the visual
mode mappings.