### PR TITLE
remove doubled autocmds

### DIFF
--- a/plugin/pandoc.vim
+++ b/plugin/pandoc.vim
@@ -98,9 +98,11 @@ endif
 " augroup pandoc {{{2
 " this sets the filetype for pandoc files
 augroup pandoc
-    au BufNewFile,BufRead *.pandoc,*.pdk,*.pd,*.pdc set filetype=pandoc
+    au BufNewFile,BufRead,BufFilePost *.pandoc,*.pdk,*.pd,*.pdc set filetype=pandoc
     if g:pandoc#filetypes#pandoc_markdown == 1
-        au BufNewFile,BufRead *.markdown,*.mkd,*.md set filetype=pandoc
+        " skip loading of /markdown/ftplugin.vim
+        au BufNewFile,BufRead,BufFilePost *.markdown,*.mdown,*.mkd,*.mkdn,*.mdwn,*.md 
+                    \ let b:did_ftplugin=1 | setlocal filetype=pandoc
     endif
 augroup END
 "}}}


### PR DESCRIPTION
This  speeds up loading pandoc files by 

- not triggering the same autcmd's twice, and
- avoiding loading the markdown filetype plug-in first (which is then overridden by that of pandoc).