### PR TITLE
pandoc/folding: don't disable foldexpr when there are multiple splits

### DIFF
--- a/autoload/pandoc/folding.vim
+++ b/autoload/pandoc/folding.vim
@@ -112,9 +112,9 @@ function! pandoc#folding#FoldExpr()
     " performance. Only enable when using the built-in method of improving
     " performance of folds.
     if g:pandoc#folding#fastfolds = 1
-    if count(map(range(1, winnr('$')), 'bufname(winbufnr(v:val))'), bufname("")) > 1
-        return
-    endif
+        if count(map(range(1, winnr('$')), 'bufname(winbufnr(v:val))'), bufname("")) > 1
+            return
+        endif
     endif
 
     let vline = getline(v:lnum)

--- a/autoload/pandoc/folding.vim
+++ b/autoload/pandoc/folding.vim
@@ -111,7 +111,7 @@ function! pandoc#folding#FoldExpr()
     " way too many times too often, so it's best to disable it to keep good
     " performance. Only enable when using the built-in method of improving
     " performance of folds.
-    if g:pandoc#folding#fastfolds = 1
+    if g:pandoc#folding#fastfolds == 1
         if count(map(range(1, winnr('$')), 'bufname(winbufnr(v:val))'), bufname("")) > 1
             return
         endif

--- a/autoload/pandoc/folding.vim
+++ b/autoload/pandoc/folding.vim
@@ -109,9 +109,12 @@ endfunction
 function! pandoc#folding#FoldExpr()
     " with multiple splits in the same buffer, the folding code can be called
     " way too many times too often, so it's best to disable it to keep good
-    " performance.
+    " performance. Only enable when using the built-in method of improving
+    " performance of folds.
+    if g:pandoc#folding#fastfolds = 1
     if count(map(range(1, winnr('$')), 'bufname(winbufnr(v:val))'), bufname("")) > 1
         return
+    endif
     endif
 
     let vline = getline(v:lnum)

--- a/doc/pandoc.txt
+++ b/doc/pandoc.txt
@@ -267,11 +267,9 @@ Besides this, some extensions are provided:
 * To avoid the continuous recomputation of folds, in particular in insert mode,
   set |g:pandoc#folding#fastfolds| to 1 to defer it to the switches between
   insert and normal mode. For a plug-in that will make Vim recompute the folds
-  only when need be, see https://github.com/konfekt/fastfold .
-
-NOTE: when using split windows, the foldexpr function can get called many more
-times than usual, so in this case the folding function is disabled for
-performance reasons.
+  only when need be, see https://github.com/konfekt/fastfold . This also
+  disables the calculation of folds when using split windows, where the foldexpr
+  function can get called many more times than usual.
 
 - COMMAND                                            *vim-pandoc-command-module*
 


### PR DESCRIPTION
unless using the inbuilt tweaks to folding performance.