### PR TITLE
Fix Pandoc! for neovim and subdirectory

### DIFF
--- a/python3/vim_pandoc/command.py
+++ b/python3/vim_pandoc/command.py
@@ -236,7 +236,7 @@ class PandocCommand(object):
             # nvim's python host doesn't change the directory the same way vim does
             try:
                 if vim.eval('has("nvim")') == '1':
-                    os.chdir(vim.eval('expand("%:p:h")'))
+                    os.chdir(vim.eval('getcwd()'))
             except:
                 pass
 


### PR DESCRIPTION
I am using neovim. If I open the file `sub/foo.md` and run `Pandoc!` the resulting `sub/foo.html` will not be opened.

This happens because in `command.py`, `self._output_file_path` is set to `sub/foo.html` and the current directory is `sub/`. Then the absolute path will be `sub/sub/foo.html` which is incorrect. Changing the `os.chdir()` call to change to the current vim working directory instead of the directory of the current buffer fixes the problem.

I don't know why the working directory was changed in that way, so I might have broken something.