### PR TITLE
Fix vim-pandoc usage with MSYS

### DIFF
--- a/python3/vim_pandoc/helpparser.py
+++ b/python3/vim_pandoc/helpparser.py
@@ -1,3 +1,4 @@
+import sys
 from subprocess import Popen, PIPE
 import re
 from collections import namedtuple
@@ -29,7 +30,12 @@ class PandocInfo(object):
         self.output_formats = self.get_output_formats()
 
     def get_version(self):
-        return self.__raw_output('--version', pattern='pandoc (\d+\.\d+)')
+        versionPattern = 'pandoc'
+        # check for MSYS terminal
+        if sys.platform.startswith('msys'):
+            versionPattern += '\.exe'
+        versionPattern += ' (\d+\.\d+)'
+        return self.__raw_output('--version', pattern=versionPattern)
 
     def get_options(self):
         # first line describes pandoc usage


### PR DESCRIPTION
This PR fixes the bug mentionned in #320.

Indeed, after an in-depth study, when I call `pandoc --version` from my MinGW64 terminal I get:
```
pandoc.exe 2.7.3
Compiled with pandoc-types 1.17.5.4, texmath 0.11.2.2, skylighting 0.8.1
Default user data directory: C:\Users\xx\AppData\Roaming\pandoc
Copyright (C) 2006-2019 John MacFarlane
Web:  http://pandoc.org
This is free software; see the source for copying conditions.
There is no warranty, not even for merchantability or fitness
for a particular purpose.
```

Whereas from a `cmd.exe`, I get:
```
pandoc 2.7.3
Compiled with pandoc-types 1.17.5.4, texmath 0.11.2.2, skylighting 0.8.1
Default user data directory: C:\Users\xx\AppData\Roaming\pandoc
Copyright (C) 2006-2019 John MacFarlane
Web:  http://pandoc.org
This is free software; see the source for copying conditions.
There is no warranty, not even for merchantability or fitness
for a particular purpose.
```

That's why I've conditionnally added the `'\.exe'` in the version regex.