### PR TITLE
reset options after switching filetype (to, say, markdown)

### DIFF
--- a/ftplugin/pandoc.vim
+++ b/ftplugin/pandoc.vim
@@ -33,4 +33,10 @@ endif
 setlocal formatlistpat=\\C^\\s*[\\[({]\\\?\\([0-9]\\+\\\|[iIvVxXlLcCdDmM]\\+\\\|[a-zA-Z]\\)[\\]:.)}]\\s\\+\\\|^\\s*[-+o*]\\s\\+
 setlocal formatoptions+=n
 
+let b:undo_ftplugin = "setlocal formatoptions< formatlistpat<"
+                \ . "| unlet b:match_pairs b:match_words"
+if !empty(g:pandoc#formatting#equalprg)
+    let b:undo_ftplugin = . "| setlocal equalprg<"
+endif
+
 let b:pandoc_loaded = 1

--- a/ftplugin/pandoc.vim
+++ b/ftplugin/pandoc.vim
@@ -35,8 +35,8 @@ setlocal formatoptions+=n
 
 let b:undo_ftplugin = "setlocal formatoptions< formatlistpat<"
                 \ . "| unlet b:match_pairs b:match_words"
-if !empty(g:pandoc#formatting#equalprg)
-    let b:undo_ftplugin = . "| setlocal equalprg<"
+if exists('g:pandoc#formatting#equalprg') && !empty(g:pandoc#formatting#equalprg)
+    let b:undo_ftplugin .= "| setlocal equalprg<"
 endif
 
 let b:pandoc_loaded = 1


### PR DESCRIPTION
Could help with https://github.com/Konfekt/vim-sentence-chopper/issues/1