### PR TITLE
Support `@online` in .bibs when using bibtool

### DIFF
--- a/autoload/pandoc/bibliographies.vim
+++ b/autoload/pandoc/bibliographies.vim
@@ -25,6 +25,11 @@ function! pandoc#bibliographies#Init() abort
         let g:pandoc#biblio#use_bibtool = 0
     endif
     "}}}
+    " Pass extra args to bibtool? {{{3
+    if !exists('g:pandoc#biblio#bibtool_extra_args')
+        let g:pandoc#biblio#bibtool_extra_args = '-r biblatex'
+    endif
+    "}}}
     " Files to add to b:pandoc_biblio_bibs if "g" is in g:pandoc#biblio#sources {{{3
     if !exists('g:pandoc#biblio#bibs')
         let g:pandoc#biblio#bibs = []

--- a/doc/pandoc.txt
+++ b/doc/pandoc.txt
@@ -506,6 +506,11 @@ you might retrieve both
 This is off by default, but can be turned on (if `bibtool` is available) by
 setting the |g:pandoc#biblio#use_bibtool| variable to 1.
 
+You can pass extra arguments to `bibtool` by setting
+|g:pandoc#biblio#bibtool_extra_args|. The default is "-r biblatex", which
+enables support for biblatex bibliographies (bibtex bibliographies will still
+work).
+
 TIP: If you use unite.vim, you might want to check https://github.com/msprev/unite-bibtex
 
 - YAML                                                 *vim-pandoc-yaml-module*

--- a/python3/vim_pandoc/bib/fallback.py
+++ b/python3/vim_pandoc/bib/fallback.py
@@ -5,6 +5,7 @@ import os
 import os.path
 import operator
 import subprocess as sp
+import shlex
 from vim_pandoc.bib.collator import SourceCollator
 from vim_pandoc.bib.util import make_title_ascii
 
@@ -32,8 +33,11 @@ def get_bibtex_suggestions(text, query, use_bibtool=False, bib=None):
     if use_bibtool:
         bibtex_id_search = re.compile(".*{\s*(?P<id>.*),")
 
-        args = "-- select{$key title booktitle author editor \"%(query)s\"}'" % {"query": query}
-        text = sp.Popen(["bibtool", "--preserve.key.case=on",  args, bib], stdout=sp.PIPE, stderr=sp.PIPE).communicate()[0]
+        extra_args = shlex.split(vim.vars["pandoc#biblio#bibtool_extra_args"])
+
+        search = ["--", "select{$key title booktitle author editor \"%(query)s\"}" % {"query": query}]
+        cmd = ["bibtool", "--preserve.key.case=on", *extra_args, *search, bib]
+        text = sp.Popen(cmd, stdout=sp.PIPE, stderr=sp.PIPE).communicate()[0]
         if isinstance(text, bytes):
             text = text.decode("utf-8")
     else:


### PR DESCRIPTION
Otherwise bibtool errors with something like this:

```
@online{laurie_penny_who_2018,
_^
*** BibTool ERROR:  (line 1966 in ./zotero.bib): Unknown entry type

*** BibTool WARNING: Skipping to next '@'
```

This has the amusing property of making bibliographic completion appear elitist by excluding blog posts ;)

It's possible that using `-r biblatex` will break some features of non-biblatex .bibs, if that's a concern there are other workarounds here: https://github.com/ge-ne/bibtool/issues/2