### PR TITLE
python/helpparser: fix version checking

### DIFF
--- a/python3/vim_pandoc/helpparser.py
+++ b/python3/vim_pandoc/helpparser.py
@@ -18,7 +18,7 @@ class PandocInfo(object):
     def __raw_output(self, cmd, pattern=None):
         data = ensure_string(Popen([self.pandoc, cmd], stdout=PIPE).communicate()[0])
         if pattern:
-            return re.search(pattern, data, re.DOTALL).group(1)
+            return re.search(pattern, data, re.DOTALL)
         else:
             return data
 
@@ -30,12 +30,8 @@ class PandocInfo(object):
         self.output_formats = self.get_output_formats()
 
     def get_version(self):
-        versionPattern = 'pandoc'
-        # check for MSYS terminal
-        if sys.platform.startswith('msys'):
-            versionPattern += '\.exe'
-        versionPattern += ' (\d+\.\d+)'
-        return self.__raw_output('--version', pattern=versionPattern)
+        versionPattern = 'pandoc(\.exe)? (?P<version>\d+\.\d+)'
+        return self.__raw_output('--version', pattern=versionPattern).group('version')
 
     def get_options(self):
         # first line describes pandoc usage


### PR DESCRIPTION
Re #327

The problem was that we only checked for the presence of `.exe` in case we detected `msys` as the platform. That is too strict. As @sticke4 pointed out, it seems like we can just allow for the presence of `.exe` as optional always. 

Additionally, we shouldn't have assumed that we would always want the first group from the output of `__raw_output(...)` in case we gave it a pattern. Instead, we should return the match object, and let the caller function do what it needs (like we now do in get_version(), where we now use a named group).