### PR TITLE
toc: bypass linter in safe case

### DIFF
--- a/autoload/pandoc/toc.vim
+++ b/autoload/pandoc/toc.vim
@@ -70,7 +70,9 @@ function! pandoc#toc#ReDisplay(bufname) abort
 
     " change the contents of the location-list buffer
     set modifiable
-    call substitute('%', '\v^([^|]*\|){2,2} #', '')
+    " vint: -ProhibitCommandWithUnintendedSideEffect -ProhibitCommandRelyOnUser
+    silent %s/\v^([^|]*\|){2,2} #//e
+    " vint: +ProhibitCommandWithUnintendedSideEffect +ProhibitCommandRelyOnUser
     for l in range(1, line('$'))
         " this is the location-list data for the current item
         let d = getloclist(0)[l-1]


### PR DESCRIPTION
I think it is safe in this instance. The option is to search for matches in the file, and set the lines with a replacement; it strikes me as reinventing the wheel.

Re: #336