### PR TITLE
Table of content improvements

### DIFF
--- a/autoload/pandoc/toc.vim
+++ b/autoload/pandoc/toc.vim
@@ -66,7 +66,7 @@ function! pandoc#toc#ReDisplay(bufname) abort
         return
     endif
     let &winwidth=(&columns/3)
-    execute 'setlocal statusline=pandoc#TOC:'.escape(a:bufname, ' ')
+    execute 'setlocal statusline=Pandoc\ TOC:\ '.escape(a:bufname, ' ')
 
     " change the contents of the location-list buffer
     set modifiable

--- a/autoload/pandoc/toc.vim
+++ b/autoload/pandoc/toc.vim
@@ -4,7 +4,7 @@ scriptencoding utf-8
 " Init(): set up defaults, create TOC command {{{1
 function! pandoc#toc#Init() abort
     " set up defaults {{{2
-    " where to open the location list {{{3
+    " where to open the location list
     if !exists('g:pandoc#toc#position')
         let g:pandoc#toc#position = 'right'
     endif
@@ -71,11 +71,11 @@ function! pandoc#toc#ReDisplay(bufname) abort
     " change the contents of the location-list buffer
     set modifiable
     " vint: -ProhibitCommandWithUnintendedSideEffect -ProhibitCommandRelyOnUser
-    silent %s/\v^([^|]*\|){2,2} #//e
+    silent %s/\v^([^|]*\|){2} #//e
     " vint: +ProhibitCommandWithUnintendedSideEffect +ProhibitCommandRelyOnUser
     for l in range(1, line('$'))
         " this is the location-list data for the current item
-        let d = getloclist(0)[l-1]
+        let d = getloclist(0)[l-1]  " -1 because numeration begins from 0
         " titleblock
         if match(d.text, '^%') > -1
             let l:level = 0

--- a/autoload/pandoc/toc.vim
+++ b/autoload/pandoc/toc.vim
@@ -11,6 +11,10 @@ function! pandoc#toc#Init() abort
     if !exists('g:pandoc#toc#close_after_navigating')
         let g:pandoc#toc#close_after_navigating = 1
     endif
+    " the number of spaces per level in toc
+    if !exists('g:pandoc#toc#shift')
+        let g:pandoc#toc#shift = 2
+    endif
     " create :TOC command {{{2
     command! -buffer TOC call pandoc#toc#Show()
     "}}}
@@ -93,7 +97,7 @@ function! pandoc#toc#ReDisplay(bufname) abort
             endif
             let d.text = '· '.d.text
         endif
-        call setline(l, repeat(' ', 2*l:level-1). d.text)
+        call setline(l, repeat(' ', g:pandoc#toc#shift*l:level). d.text)
     endfor
     set nomodified
     set nomodifiable

--- a/doc/pandoc.txt
+++ b/doc/pandoc.txt
@@ -718,6 +718,9 @@ buffer is closed after this, but this can be circumvented by pressing <C-CR>.
 This behavior can be reversed by setting |g:pandoc#toc#close_after_navigating|
 to 0.
 
+The indentation in the TOC buffer can be tuned by |g:pandoc#toc#shift|
+variable, which definds the shift in number of spaces per level.
+
 - SPELL                                                *vim-pandoc-spell-module*
 
 Sets up spelling for files handled by vim-pandoc. Spelling is on by default,
@@ -1105,6 +1108,12 @@ A description of the available configuration variables follows:
   Must the TOC window close after selecting a location? This also controls the
   behavior of the <CR> key. If '1', <CR> navigates and closes the TOC, <C-CR>
   simply navigates. If '0', this behavior is reversed.
+
+- *g:pandoc#toc#shift*
+  default = 2
+
+  Defines the number of spaces per level to indent the higher level
+  positions in TOC buffer.
 
 - *g:pandoc#spell#enabled*
   default = 1


### PR DESCRIPTION
Add new option to tune the indentation in TOC buffer: set the number of spaces per level. The default is 2. And make the statusline title of the toc buffer more readable.