### PR TITLE
Typo describing command behavior in nvim

### DIFF
--- a/doc/pandoc.txt
+++ b/doc/pandoc.txt
@@ -299,8 +299,8 @@ will create an incantation like:
 In nvim, vim-pandoc will open a terminal buffer and execute pandoc. If the
 value of |g:pandoc#command#use_message_buffers| is 1 and some error occurred,
 a buffer will open displaying the command output (this is unnecessary in nvim,
-because it will always display the command output, so the defalt for
-`use_message_buffers' there is 0). You can dismiss these buffers pressing 'q'.
+because it will always display the command output, so the default value for
+`use_message_buffers' is 0). You can dismiss these buffers pressing 'q'.
 
 Regardless of pandoc's execution status, the invocation used will be logged so
 it can be checked using |:messages|.


### PR DESCRIPTION
Hi,

I found a typo in the doc, I thought I would fix it for you.

Just one additional thought about this : what happens if `use_message_buffers` is set to `1` ? Maybe this documentation should say something like "for nvim parameter `use_message_buffers` is not considered".

Just a small contribution, please forgive me if this was not the right way to bring this up.

Matthias