### PR TITLE
Move ftdetect functions to proper location

### DIFF
--- a/ftdetect/pandoc.vim
+++ b/ftdetect/pandoc.vim
@@ -1,15 +1,11 @@
-augroup pandoc_ftdetect
-    autocmd!
-augroup END
-
-autocmd pandoc_ftdetect BufNewFile,BufRead,BufFilePost *.pandoc,*.pdk,*.pd,*.pdc set filetype=pandoc
+autocmd BufNewFile,BufRead,BufFilePost *.pandoc,*.pdk,*.pd,*.pdc set filetype=pandoc
 
 if !exists('g:pandoc#filetypes#pandoc_markdown')
     let g:pandoc#filetypes#pandoc_markdown = 1
 endif
 
 if g:pandoc#filetypes#pandoc_markdown == 1
-    autocmd pandoc_ftdetect BufNewFile,BufRead,BufFilePost *.markdown,*.mdown,*.mkd,*.mkdn,*.mdwn,*.md
+    autocmd BufNewFile,BufRead,BufFilePost *.markdown,*.mdown,*.mkd,*.mkdn,*.mdwn,*.md
                 \ let b:did_ftplugin=1 | setlocal filetype=pandoc
 endif
 

--- a/ftdetect/pandoc.vim
+++ b/ftdetect/pandoc.vim
@@ -1,0 +1,16 @@
+augroup pandoc_ftdetect
+    autocmd!
+augroup END
+
+autocmd pandoc_ftdetect BufNewFile,BufRead,BufFilePost *.pandoc,*.pdk,*.pd,*.pdc set filetype=pandoc
+
+if !exists('g:pandoc#filetypes#pandoc_markdown')
+    let g:pandoc#filetypes#pandoc_markdown = 1
+endif
+
+if g:pandoc#filetypes#pandoc_markdown == 1
+    autocmd pandoc_ftdetect BufNewFile,BufRead,BufFilePost *.markdown,*.mdown,*.mkd,*.mkdn,*.mdwn,*.md
+                \ let b:did_ftplugin=1 | setlocal filetype=pandoc
+endif
+
+" vim: set fdm=marker et ts=4 sw=4 sts=4 :

--- a/plugin/pandoc.vim
+++ b/plugin/pandoc.vim
@@ -70,12 +70,6 @@ if v:version < 704
     endif
 endif
 "}}}
-" Filetypes: {{{2
-" Use pandoc extensions to markdown for all markdown files {{{3
-if !exists('g:pandoc#filetypes#pandoc_markdown')
-    let g:pandoc#filetypes#pandoc_markdown = 1
-endif
-"}}}
 " Markups to handle {{{3
 if !exists('g:pandoc#filetypes#handled')
         let g:pandoc#filetypes#handled = [
@@ -94,17 +88,6 @@ endif
 " the value of g:pandoc#filetypes#handled and
 " g:pandoc#filetypes#pandoc_markdown
 
-" augroup pandoc {{{2
-" this sets the filetype for pandoc files
-augroup pandoc
-    au BufNewFile,BufRead,BufFilePost *.pandoc,*.pdk,*.pd,*.pdc set filetype=pandoc
-    if g:pandoc#filetypes#pandoc_markdown == 1
-        " skip loading of /markdown/ftplugin.vim
-        au BufNewFile,BufRead,BufFilePost *.markdown,*.mdown,*.mkd,*.mkdn,*.mdwn,*.md
-                    \ let b:did_ftplugin=1 | setlocal filetype=pandoc
-    endif
-augroup END
-"}}}
 " augroup pandoc_attach {{{2
 " this loads the vim-pandoc functionality for configured extensions
 augroup pandoc_attach


### PR DESCRIPTION
Closes #349 

Need to review when `g:pandoc#filetypes#pandoc_markdown` might get set in relation to this.