### PR TITLE
add keyboard submodule for checkboxes

### DIFF
--- a/autoload/pandoc/keyboard.vim
+++ b/autoload/pandoc/keyboard.vim
@@ -5,7 +5,7 @@ function! pandoc#keyboard#Init() abort
     " set up defaults {{{2
     " Enabled submodules {{{3
     if !exists('g:pandoc#keyboard#enabled_submodules')
-        let g:pandoc#keyboard#enabled_submodules = ['lists', 'sections', 'styles', 'references', 'links', 'para']
+        let g:pandoc#keyboard#enabled_submodules = ['lists', 'sections', 'styles', 'references', 'links', 'para', 'checkboxes']
     endif
     " Use display motions when using soft wrapping {{{3
     if !exists('g:pandoc#keyboard#display_motions')

--- a/autoload/pandoc/keyboard/checkboxes.vim
+++ b/autoload/pandoc/keyboard/checkboxes.vim
@@ -1,0 +1,46 @@
+" vim: set fdm=marker et ts=4 sw=4 sts=4:
+
+function! pandoc#keyboard#checkboxes#Init() "{{{1
+
+	 " Toggle existing checkbox or insert checkbox.
+    noremap <buffer> <silent> <Plug>(pandoc-keyboard-toggle-cb) :call pandoc#keyboard#checkboxes#Toggle()<cr>
+	 " Remove existing checkbox
+    noremap <buffer> <silent> <Plug>(pandoc-keyboard-delete-cb) :call pandoc#keyboard#checkboxes#Delete()<cr>
+    if g:pandoc#keyboard#use_default_mappings == 1 && index(g:pandoc#keyboard#blacklist_submodule_mappings, "checkboxes") == -1
+        nmap <buffer> <localleader>cb <Plug>(pandoc-keyboard-toggle-cb)
+        vmap <buffer> <localleader>cb <Plug>(pandoc-keyboard-toggle-cb)
+        nmap <buffer> <localleader>cd <Plug>(pandoc-keyboard-delete-cb)
+        vmap <buffer> <localleader>cd <Plug>(pandoc-keyboard-delete-cb)
+    endif
+endfunction
+
+" Functions: {{{1
+
+function! pandoc#keyboard#checkboxes#Toggle() "{{{2
+	let l:line=getline('.')
+	let l:curs=winsaveview()
+
+	" match '- [ ]' and replace with '- [x]'
+	if l:line=~?'^\s*\(-\|\*\)\s*\[ \] .*'
+		:call setline(line('.'), substitute(l:line, '\[ \]', '\[x\]', ''))
+
+	" match '- [x]' and replace with '- [ ]'
+	elseif l:line=~?'^\s*\(-\|\*\)\s*\[x\] .*'
+		:call setline(line('.'), substitute(l:line, '\[x\]', '\[ \]', ''))
+
+	" match list item that does not have a [ at the beginning
+	elseif l:line=~?'^\s*\(-\|\*\)\s*[^\[].*'
+		:call setline(line('.'), substitute(l:line, '^\s*\(-\|\*\)', '\0 \[ \]', ''))
+	endif
+	call winrestview(l:curs)
+endfunction
+
+function! pandoc#keyboard#checkboxes#Delete() "{{{2
+	let l:line=getline('.')
+	let l:curs=winsaveview()
+
+	if l:line=~?'^\s*\(-\|\*\)\s*\[[^\]]\] .*'
+		:call setline(line('.'), substitute(l:line, '^\s*\(-\|\*\)\s*\zs\(\[[^\]]\]\) \ze', '', ''))
+	endif
+	call winrestview(l:curs)
+endfunction

--- a/autoload/pandoc/keyboard/checkboxes.vim
+++ b/autoload/pandoc/keyboard/checkboxes.vim
@@ -1,12 +1,12 @@
 " vim: set fdm=marker et ts=4 sw=4 sts=4:
 
-function! pandoc#keyboard#checkboxes#Init() "{{{1
+function! pandoc#keyboard#checkboxes#Init() abort "{{{1
 
 	 " Toggle existing checkbox or insert checkbox.
     noremap <buffer> <silent> <Plug>(pandoc-keyboard-toggle-cb) :call pandoc#keyboard#checkboxes#Toggle()<cr>
 	 " Remove existing checkbox
     noremap <buffer> <silent> <Plug>(pandoc-keyboard-delete-cb) :call pandoc#keyboard#checkboxes#Delete()<cr>
-    if g:pandoc#keyboard#use_default_mappings == 1 && index(g:pandoc#keyboard#blacklist_submodule_mappings, "checkboxes") == -1
+    if g:pandoc#keyboard#use_default_mappings == 1 && index(g:pandoc#keyboard#blacklist_submodule_mappings, 'checkboxes') == -1
         nmap <buffer> <localleader>cb <Plug>(pandoc-keyboard-toggle-cb)
         vmap <buffer> <localleader>cb <Plug>(pandoc-keyboard-toggle-cb)
         nmap <buffer> <localleader>cd <Plug>(pandoc-keyboard-delete-cb)
@@ -16,7 +16,7 @@ endfunction
 
 " Functions: {{{1
 
-function! pandoc#keyboard#checkboxes#Toggle() "{{{2
+function! pandoc#keyboard#checkboxes#Toggle() abort "{{{2
 	let l:line=getline('.')
 	let l:curs=winsaveview()
 
@@ -35,7 +35,7 @@ function! pandoc#keyboard#checkboxes#Toggle() "{{{2
 	call winrestview(l:curs)
 endfunction
 
-function! pandoc#keyboard#checkboxes#Delete() "{{{2
+function! pandoc#keyboard#checkboxes#Delete() abort "{{{2
 	let l:line=getline('.')
 	let l:curs=winsaveview()
 

--- a/doc/pandoc.txt
+++ b/doc/pandoc.txt
@@ -438,6 +438,8 @@ where they are available):
 - *<localleader>lcf*   move to the first list item child [n]
 - *<localleader>lcl*   move to the last list item child [n]
 - *<localleader>lcn*   move to the [count] nth list item child [n]
+- *<localleader>cb*    toggle checkbox or insert empty checkbox in list item [vn]
+- *<localleader>cd*    remove existing checkbox from list item [vn]
 
 For |<localleader>#|, you can decide what header style to use (always atx, use
 setex, append hashes at the end) by setting the
@@ -985,7 +987,7 @@ A description of the available configuration variables follows:
   |preview-window|? Requires the 'citeproc' backend.
 
 - *g:pandoc#keyboard#enabled_submodules*
-  default = ["lists", "references", "styles", "sections", "links"]
+  default = ["lists", "references", "styles", "sections", "links", "checkboxes"]
 
   What mapping groups to enable.
 


### PR DESCRIPTION
Checkboxes have been introduced by [Github Flavoured Markdown](https://github.github.com/gfm/#task-list-items-extension-) and are also supported in pandoc by the task_lists extension.