### PR TITLE
markdown filetype check: use get()

### DIFF
--- a/ftdetect/pandoc.vim
+++ b/ftdetect/pandoc.vim
@@ -1,11 +1,7 @@
 " vint: -ProhibitAutocmdWithNoGroup
 autocmd BufNewFile,BufRead,BufFilePost *.pandoc,*.pdk,*.pd,*.pdc set filetype=pandoc
 
-if !exists('g:pandoc#filetypes#pandoc_markdown')
-    let g:pandoc#filetypes#pandoc_markdown = 1
-endif
-
-if g:pandoc#filetypes#pandoc_markdown == 1
+if get(g:, 'pandoc#filetypes#pandoc_markdown', 1) == 1
     autocmd BufNewFile,BufRead,BufFilePost *.markdown,*.mdown,*.mkd,*.mkdn,*.mdwn,*.md
                 \ let b:did_ftplugin=1 | setlocal filetype=pandoc
 endif

--- a/plugin/pandoc.vim
+++ b/plugin/pandoc.vim
@@ -76,7 +76,7 @@ if !exists('g:pandoc#filetypes#handled')
         			\'pandoc',
         			\'rst',
         			\'textile']
-        if get(g:, 'pandoc#filetypes#pandoc_markdown', 0) == 1
+        if get(g:, 'pandoc#filetypes#pandoc_markdown', 1) == 1
             let g:pandoc#filetypes#handled += ['markdown']
         endif
 endif

--- a/plugin/pandoc.vim
+++ b/plugin/pandoc.vim
@@ -76,7 +76,7 @@ if !exists('g:pandoc#filetypes#handled')
         			\'pandoc',
         			\'rst',
         			\'textile']
-        if g:pandoc#filetypes#pandoc_markdown == 1
+        if get(g:, 'pandoc#filetypes#pandoc_markdown', 0) == 1
             let g:pandoc#filetypes#handled += ['markdown']
         endif
 endif


### PR DESCRIPTION
Fixes this startup error for me:

```
Error detected while processing /home/doron/.files/.config/nvim/bundle/pandoc/plugin/pandoc.vim:
line   79:
E121: Undefined variable: g:pandoc#filetypes#pandoc_markdown
E15: Invalid expression: g:pandoc#filetypes#pandoc_markdown == 1
```

~~Might fix (NOT) https://github.com/vim-pandoc/vim-pandoc/issues/342 as well.~~