### PR TITLE
Fix placeholders in templates

### DIFF
--- a/autoload/pandoc/command.vim
+++ b/autoload/pandoc/command.vim
@@ -109,7 +109,9 @@ function! s:ExpandArgs(args) abort
                 \'\=expand(submatch(0))', 'g') " expand placeholders
     let templatized_args = substitute(expanded_args, '#\(\S\+\)',
                 \'\=pandoc#command#GetTemplate(submatch(1))', 'g') " expand templates
-    return eval('templatized_args')
+    let expanded_template = substitute(templatized_args, '%\(:[phtre]\)\+',
+                \'\=expand(submatch(0))', 'g') " expand placeholders again
+    return eval('expanded_template')
 endfunction
 
 " PandocComplete(a, c, pos): the Pandoc command argument completion func, requires python support {{{2


### PR DESCRIPTION
I have no experience with vim script but this seemed like an easy fix for Issue #371.

Instead of expanding placeholders only before templates, now we do it after templates too. This might be unnecessary, as it might only be needed after template expansion but I don't know if that's safe.

In my limited testing it works as it should.