### PR TITLE
Switch order of placeholder and template expansion so that templates can use placeholders

### DIFF
--- a/autoload/pandoc/command.vim
+++ b/autoload/pandoc/command.vim
@@ -109,7 +109,9 @@ function! s:ExpandArgs(args) abort
                 \'\=expand(submatch(0))', 'g') " expand placeholders
     let templatized_args = substitute(expanded_args, '#\(\S\+\)',
                 \'\=pandoc#command#GetTemplate(submatch(1))', 'g') " expand templates
-    return eval('templatized_args')
+    let expanded_template = substitute(templatized_args, '%\(:[phtre]\)\+',
+                \'\=expand(submatch(0))', 'g') " expand placeholders again
+    return eval('expanded_template')
 endfunction
 
 " PandocComplete(a, c, pos): the Pandoc command argument completion func, requires python support {{{2

--- a/autoload/pandoc/command.vim
+++ b/autoload/pandoc/command.vim
@@ -105,13 +105,11 @@ function! pandoc#command#PandocNative(args, bang) abort
 endfunction
 
 function! s:ExpandArgs(args) abort
-    let expanded_args = substitute(a:args, '%\(:[phtre]\)\+',
-                \'\=expand(submatch(0))', 'g') " expand placeholders
-    let templatized_args = substitute(expanded_args, '#\(\S\+\)',
+    let templatized_args = substitute(a:args, '#\(\S\+\)',
                 \'\=pandoc#command#GetTemplate(submatch(1))', 'g') " expand templates
-    let expanded_template = substitute(templatized_args, '%\(:[phtre]\)\+',
-                \'\=expand(submatch(0))', 'g') " expand placeholders again
-    return eval('expanded_template')
+    let expanded_args = substitute(templatized_args, '%\(:[phtre]\)\+',
+                \'\=expand(submatch(0))', 'g') " expand placeholders
+    return eval('expanded_args')
 endfunction
 
 " PandocComplete(a, c, pos): the Pandoc command argument completion func, requires python support {{{2


### PR DESCRIPTION
A better fix for issue #371 (compared to PR #372), in this one we only swap the order of the template and placeholder expansion.