### PR TITLE
Custom foldlevel for YAML frontmatters

### DIFF
--- a/autoload/pandoc/folding.vim
+++ b/autoload/pandoc/folding.vim
@@ -21,6 +21,10 @@ function! pandoc#folding#Init() abort
     if !exists('g:pandoc#folding#fold_yaml')
         let g:pandoc#folding#fold_yaml = 0
     endif
+    " Set YAML foldlevel {{{3
+    if !exists('g:pandoc#folding#foldlevel_yaml')
+        let g:pandoc#folding#foldlevel_yaml = 1
+    endif
     " What <div> classes to fold {{{3
     if !exists('g:pandoc#folding#fold_div_classes')
         let g:pandoc#folding#fold_div_classes = ['notes']
@@ -122,13 +126,13 @@ function! pandoc#folding#FoldExpr() abort
     if g:pandoc#folding#fold_yaml == 1
         if vline =~# '\(^---$\|^...$\)' && synIDattr(synID(v:lnum , 1, 1), 'name') =~? '\(delimiter\|yamldocumentstart\)'
             if vline =~# '^---$' && v:lnum == 1
-                return '>1'
+                return '>' . g:pandoc#folding#foldlevel_yaml
             elseif synIDattr(synID(v:lnum - 1, 1, 1), 'name') ==# 'yamlkey'
-                return '<1'
+                return '<' . g:pandoc#folding#foldlevel_yaml
             elseif synIDattr(synID(v:lnum - 1, 1, 1), 'name') ==# 'pandocYAMLHeader'
-                return '<1'
+                return '<' . g:pandoc#folding#foldlevel_yaml
             elseif synIDattr(synID(v:lnum - 1, 1, 1), 'name') ==# 'yamlBlockMappingKey'
-                return '<1'
+                return '<' . g:pandoc#folding#foldlevel_yaml
             else
                 return '='
             endif

--- a/doc/pandoc.txt
+++ b/doc/pandoc.txt
@@ -232,6 +232,8 @@ Besides this, some extensions are provided:
 
 * If present, fold the document's YAML frontmatter (this is configurable with
   |g:pandoc#folding#fold_yaml|)
+* The foldlevel for YAML frontmatter is 1 by default (this is configurable
+  with |g:pandoc#folding#folding_yaml|)
 * Fold divs of the classes defined in |g:pandoc#folding#fold_div_classes|. For
   example, you might want to create notes for a presentation. pandoc
   understands
@@ -1062,6 +1064,11 @@ A description of the available configuration variables follows:
   default = 0
 
   Fold YAML frontmatters.
+
+- *g:pandoc#folding#folding_yaml*
+  default = 1
+
+  Foldlevel for YAML frontmatters.
 
 - *g:pandoc#folding#fold_div_classes*
   default = ["notes"]


### PR DESCRIPTION
The foldlevel of the YAML frontmatter ist 1. The YAML frontmatter is rarely edited so the foldlevel should be customizable (i.e. higher). The default is 1 so this commit should not break any workflow.