### PR TITLE
Remove erroneous put statement

### DIFF
--- a/python3/vim_pandoc/command.py
+++ b/python3/vim_pandoc/command.py
@@ -153,7 +153,6 @@ class PandocCommand(object):
                 if int(vim.eval("bufloaded('pandoc-execute')")):
                     wnr = vim.eval("bufwinnr('pandoc-execute')")
                     vim.command(wnr + "wincmd c")
-                    vim.command(wnr + "put='Running pandoc...\n'")
 
                 vim.command("botright 7new pandoc-execute")
                 vim.command("setlocal buftype=nofile")


### PR DESCRIPTION
The `:Pandoc` command would produce an internal error *after* pandoc itself has failed in an `:Pandoc` call before (e.g. illegal Latex macro when producing PDF). I have removed the corresponding line.

`:put` does not accept a window number as count, but a line.
The newline character produced an error instead of inserting text into a
random buffer.

Related to issue #360