### PR TITLE
keyboard/para: buffer local mappings

### DIFF
--- a/autoload/pandoc/keyboard/para.vim
+++ b/autoload/pandoc/keyboard/para.vim
@@ -1,6 +1,6 @@
 function! pandoc#keyboard#para#Init() abort
     if g:pandoc#keyboard#use_default_mappings == 1 && index(g:pandoc#keyboard#blacklist_submodule_mappings, 'para') == -1
-        noremap <localleader>o }o<esc>O
-        noremap <localleader>O {O<esc>o
+        noremap <buffer> <localleader>o }o<esc>O
+        noremap <buffer> <localleader>O {O<esc>o
     endif
 endfunction


### PR DESCRIPTION
*Edited on GitHub, therefore untested*

Mappings should be local to the buffer.