### PR TITLE
use standard b:did_ftplugin instead of custom variable b:pandoc_loaded

### DIFF
--- a/ftdetect/pandoc.vim
+++ b/ftdetect/pandoc.vim
@@ -2,8 +2,10 @@
 autocmd BufNewFile,BufRead,BufFilePost *.pandoc,*.pdk,*.pd,*.pdc set filetype=pandoc
 
 if get(g:, 'pandoc#filetypes#pandoc_markdown', 1) == 1
-    autocmd BufNewFile,BufRead,BufFilePost *.markdown,*.mdown,*.mkd,*.mkdn,*.mdwn,*.md
-                \ let b:did_ftplugin=1 | setlocal filetype=pandoc
+	if exists('#filetypedetect#BufNewFile,BufRead#*.{md,markdown,mdown,mkd,mkdn}')
+        autocmd! filetypedetect BufNewFile,BufRead *.{md,markdown,mdown,mkd,mkdn}
+    endif
+    autocmd BufNewFile,BufRead,BufFilePost *.{md,markdown,mdown,mkd,mkdn} setlocal filetype=pandoc
 endif
 
 " vim: set fdm=marker et ts=4 sw=4 sts=4 :

--- a/ftplugin/pandoc.vim
+++ b/ftplugin/pandoc.vim
@@ -11,9 +11,13 @@
 " GH: https://github.com/vim-pandoc/vim-pandoc/issues/433
 runtime! plugin/pandoc.vim
 
-if exists('b:pandoc_loaded') && b:pandoc_loaded == 1
-    finish
+if (exists('b:did_ftplugin'))
+  finish
 endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
 
 " Start a new auto command group for all this plugin's hooks
 augroup VimPandoc
@@ -64,4 +68,5 @@ if exists('g:pandoc#formatting#equalprg') && !empty(g:pandoc#formatting#equalprg
     let b:undo_ftplugin .= '| setlocal equalprg<'
 endif
 
-let b:pandoc_loaded = 1
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/ftplugin/pandoc.vim
+++ b/ftplugin/pandoc.vim
@@ -16,8 +16,8 @@ if (exists('b:did_ftplugin'))
 endif
 let b:did_ftplugin = 1
 
-let s:cpo_save = &cpo
-set cpo&vim
+let s:cpo_save = &cpoptions
+set cpoptions&vim
 
 " Start a new auto command group for all this plugin's hooks
 augroup VimPandoc
@@ -68,5 +68,5 @@ if exists('g:pandoc#formatting#equalprg') && !empty(g:pandoc#formatting#equalprg
     let b:undo_ftplugin .= '| setlocal equalprg<'
 endif
 
-let &cpo = s:cpo_save
+let &cpoptions = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
Since

```viml
def LoadFTPlugin()
  if exists("b:undo_ftplugin")
    # We assume b:undo_ftplugin is using legacy script syntax
    legacy exe b:undo_ftplugin
    unlet! b:undo_ftplugin b:did_ftplugin
  endif
...
enddef
```

unsets b:did_ftplugin, but not b:pandoc_loaded, reloading the filetype will not reaload the ftplugin.
Instead we remove the autocmd's that set the markdown filetype

Closes #237