### PR TITLE
Fix: Default bib sources flags

### DIFF
--- a/doc/pandoc.txt
+++ b/doc/pandoc.txt
@@ -493,7 +493,7 @@ the corresponding flag to give g:pandoc#biblio#sources):
 6) [y] Add any bibliographies specified in a YAML header.
 7) [G] Add any bibliographies in the current git repository.
 
-The default flags are "bcgyG". For the 'c', 'l', and 't' flags, the
+The default flags are "bcgy". For the 'c', 'l', and 't' flags, the
 |g:pandoc#biblio#bib_extensions| is taken into account. You can, of
 course, modify the value of |b:pandoc_biblio_bibs| at any time.
 


### PR DESCRIPTION
The default bibliography sources flags are "bcgy", not "bcgyG" as the help text previously described.