### PR TITLE
fix #444

### DIFF
--- a/autoload/pandoc/hypertext.vim
+++ b/autoload/pandoc/hypertext.vim
@@ -98,7 +98,7 @@ function! s:ExtendedCFILE() abort
     let orig_isfname = &isfname
     let &isfname = orig_isfname . ',?,&,:'
     let addr = expand('<cfile>')
-    if addr[0] != '/'
+    if addr[0] !=# '/'
         let addr = expand('%:h') . '/' . addr
     endif
     let &isfname = orig_isfname

--- a/autoload/pandoc/hypertext.vim
+++ b/autoload/pandoc/hypertext.vim
@@ -97,7 +97,10 @@ endfunction
 function! s:ExtendedCFILE() abort
     let orig_isfname = &isfname
     let &isfname = orig_isfname . ',?,&,:'
-    let addr = expand('%:h') . '/' . expand('<cfile>')
+    let addr = expand('<cfile>')
+    if addr[0] != '/'
+        let addr = expand('%:h') . '/' . addr
+    endif
     let &isfname = orig_isfname
     return addr
 endfunction

--- a/autoload/pandoc/hypertext.vim
+++ b/autoload/pandoc/hypertext.vim
@@ -98,7 +98,7 @@ function! s:ExtendedCFILE() abort
     let orig_isfname = &isfname
     let &isfname = orig_isfname . ',?,&,:'
     let addr = expand('<cfile>')
-    if addr[0] !=# '/'
+    if !isabsolutepath(addr)
         let addr = expand('%:h') . '/' . addr
     endif
     let &isfname = orig_isfname

--- a/autoload/pandoc/hypertext.vim
+++ b/autoload/pandoc/hypertext.vim
@@ -97,7 +97,7 @@ endfunction
 function! s:ExtendedCFILE() abort
     let orig_isfname = &isfname
     let &isfname = orig_isfname . ',?,&,:'
-    let addr = expand('<cfile>')
+    let addr = expand('%:h') . '/' . expand('<cfile>')
     let &isfname = orig_isfname
     return addr
 endfunction


### PR DESCRIPTION
fix #444 by making `s:ExtendedCFILE()` to return full or cwd-relative path.
I believe this change doesn't cause any error in windows. I have a small question; for what reason does `pandoc#hypertext#GotoID()` not use `s:ExtendedCFILE()`? In other word, why others use?