### PR TITLE
Fix ValueError from missing --trace option in Pandoc v3.1

### DIFF
--- a/python3/vim_pandoc/helpparser.py
+++ b/python3/vim_pandoc/helpparser.py
@@ -38,7 +38,10 @@ class PandocInfo(object):
         data = self.__raw_output('--help').splitlines()[1:]
         data = [l.strip() for l in data]
         # options from --trace onwards are not meaningful for us
-        cutoff = data.index('--trace')
+        try:
+            cutoff = data.index('--trace')
+        except ValueError:
+            cutoff = -1
         data = data[:cutoff]
 
         options = []


### PR DESCRIPTION
Problem: Pandoc command fails after users upgrade to Pandoc v3.1.

On newer versions of Pandoc (v3.1.*), no `--trace` option is present from the help menu command line.

This corrects commit 05f110280326e7a389288f1a88f58f1b5901c6fb in a backwards compatible way.

Fixes #450 