### PR TITLE
fix(helpparser): regex parse list-extnsions

### DIFF
--- a/python3/vim_pandoc/helpparser.py
+++ b/python3/vim_pandoc/helpparser.py
@@ -80,8 +80,8 @@ class PandocInfo(object):
         return list(chain.from_iterable([v.names for v in self.options]))
 
     def get_extensions(self):
-        data = self.__raw_output('--list-extensions').\
-            replace(' +', '').replace(' -', '')
+        data = self.__raw_output('--list-extensions')
+        data = re.sub('(^ |^)[\+-]', '', data, flags=re.MULTILINE)
         return data.splitlines()
 
     def get_input_formats(self):


### PR DESCRIPTION
Close Issue #457.

Change from string.replace() to re.sub in get_extensions() to strip leading space and/or + and - from pandoc --list-extensions. Maintain backwards compatibility for versions that include the space character. get_extensions() expected a space at the beginning of each line, which fails because pandoc --list-extensions no longer includes the space.