### PR TITLE
Fix link regex to not match multiple links per-line

### DIFF
--- a/autoload/pandoc/hypertext.vim
+++ b/autoload/pandoc/hypertext.vim
@@ -35,7 +35,7 @@ function! pandoc#hypertext#Init() abort
     if exists('g:pandoc#hypertext#inline_link_regex')
         let s:inline_link_regex = g:pandoc#hypertext#inline_link_regex
     else
-        let s:inline_link_regex = '\v!?\[[^]]+\]\(([^) \t]+).*\)'
+        let s:inline_link_regex = '\v!?\[[^]]+\]\(([^) \t]+)\)'
     endif
 
     if exists('g:pandoc#hypertext#reference_link_regex')


### PR DESCRIPTION
Currently, the inline link regex is too inclusive. For instance, this means that if you have two links on a line, and try to go to the second link (with eg. `<localleader>gl`), it'll instead take you to the first.