### PR TITLE
Teach `formatlistpat` about nested lists and block quotes

### DIFF
--- a/ftplugin/pandoc.vim
+++ b/ftplugin/pandoc.vim
@@ -59,7 +59,7 @@ let b:match_words .=
       \ ',' . '\%(^\s*\)\@<=\\begin{\(\w\+\*\?\)}' . ':' . '\%(^\s*\)\@<=\\end{\1}'
 endif
 
-setlocal formatlistpat=\\C^\\s*[\\[({]\\\?\\([0-9]\\+\\\|[iIvVxXlLcCdDmM]\\+\\\|[a-zA-Z]\\)[\\]:.)}]\\s\\+\\\|^\\s*[-+o*]\\s\\+
+setlocal formatlistpat=\\C^\\s*\\([\\[({]\\\?\\([0-9]\\+\\\|[iIvVxXlLcCdDmM]\\+\\\|[a-zA-Z]\\)[\\]:.)}]\\s\\+\\\|[-+o*>]\\s\\+\\)\\+
 setlocal formatoptions+=n
 
 let b:undo_ftplugin = 'setlocal formatoptions< formatlistpat< matchpairs<'


### PR DESCRIPTION
The `'formatlistpat'` option, which is used to recognize lists for the purposes of `'breakindent'` (hanging line indents on soft-wrapped lines) and `'formatoptions+=n'` (same, but hard wrapped lines), was not recognizing nested lists.

**Before**
<img width="642" alt="Screenshot 2025-04-16 at 11 49 00 AM" src="https://github.com/user-attachments/assets/bc850101-10c5-4110-b64c-0261f2cfb517" />

**After**
<img width="624" alt="Screenshot 2025-04-16 at 11 48 26 AM" src="https://github.com/user-attachments/assets/a98b9f32-0ad9-478e-8ced-9d53d1a263ca" />

Note how the "before" image only hangs the indent one level, while after, in the list like `> > 1.` the second hangs all the way to the third level.

Context about `'formatlistpat'`:

<img width="565" alt="Screenshot 2025-04-16 at 11 50 23 AM" src="https://github.com/user-attachments/assets/054bfc1b-5610-4608-a804-7e8a6839aa76" />