### PR TITLE
OpenSystem for Mac should do the same escaping as for unix.

### DIFF
--- a/autoload/pandoc/hypertext.vim
+++ b/autoload/pandoc/hypertext.vim
@@ -284,7 +284,7 @@ function! pandoc#hypertext#OpenSystem(...) abort
     elseif has('win32') || has('win64')
         call system('cmd /c "start '. addr .'"')
     elseif has('macunix')
-        call system('open '. addr)
+        call system('open '. shellescape(expand(addr,':p')))
     endif
 endfunction
 


### PR DESCRIPTION
Without the added shellescape some URLs don't open up on Mac, as the shell interprets the content wrongly (especially question marks). Adding the same procedures as for 'unix' corrects the issue.