### PR TITLE
Updated Python version in Vint Github Action Workflow

### DIFF
--- a/.github/workflows/vint.yml
+++ b/.github/workflows/vint.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.10.19 
     - name: Setup dependencies
       run: pip install vim-vint
     - name: Run Vimscript Linter

--- a/.github/workflows/vint.yml
+++ b/.github/workflows/vint.yml
@@ -1,6 +1,6 @@
 name: Vint
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 
 jobs:
   vint:

--- a/.github/workflows/vint.yml
+++ b/.github/workflows/vint.yml
@@ -1,6 +1,6 @@
 name: Vint
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   vint:


### PR DESCRIPTION
Saw that `Vint` was failing on every run due to an outdated Python version being used. It was a very quick fix, so I thought I'd just do it quickly.

Updated from `3.7` to `3.10.19`