### PR TITLE
fix outdated url in readme

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -4,13 +4,13 @@
 
 `vim-pandoc` provides facilities to integrate Vim with the [pandoc][] document
 converter and work with documents written in [its markdown
-variant](http://johnmacfarlane.net/pandoc/README.html#pandocs-markdown)
+variant](https://pandoc.org/MANUAL.html#pandocs-markdown)
 (although textile documents are also supported). 
 
 `vim-pandoc`'s goals are 1) to provide advanced integration with pandoc, 2) a
 comfortable document writing environment, and 3) great configurability.
 
-[pandoc]: http://johnmacfarlane.net/pandoc/
+[pandoc]: https://pandoc.org/
 
 ## IMPORTANT
 


### PR DESCRIPTION
Replace links to Pandoc's author by links to Pandoc official website.
(Current link to Pandoc's markdown variant point to a non-existing page.)
